### PR TITLE
Incorporate fix for https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/381.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -203,6 +203,15 @@ module ActiveRecord
           sql = "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
           super
         end
+        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
+          sql = if pk && self.class.use_output_inserted
+            quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
+            sql.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"
+          else
+            "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
+          end
+          super
+        end
         # === SQLServer Specific ======================================== #
 
         def binds_have_identity_column?(binds)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -200,10 +200,6 @@ module ActiveRecord
         end
 
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          sql = "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
-          super
-        end
-        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
           sql = if pk && self.class.use_output_inserted
             quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
             sql.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"


### PR DESCRIPTION
This corrects an error when trying to insert an Address, observed in
https://ncsasports.atlassian.net/browse/PREM-340. This is an instance of
this issue: https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/339, where there are errors inserting into tables with a trigger enabled.

Note that in addition to updating this gem, for Rails >= 4.2.3, an initializer in the main app is required, as described in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/381#issuecomment-76366715. (This initializer has already been merged to c3po master, see config/initializers/sqlserver_adapter381.rb)
